### PR TITLE
Feat/improving slack output format

### DIFF
--- a/baseapp_ai_langkit/slack/admin.py
+++ b/baseapp_ai_langkit/slack/admin.py
@@ -250,7 +250,7 @@ class SlackAIChatMessageAdmin(ModelAdmin):
 class SlackAIChatMessageReactionAdmin(ModelAdmin):
     list_display = (
         "id",
-        "user_link",
+        "user_email",
         "slack_chat_message_link",
         "reaction",
         "slack_user_message",
@@ -276,11 +276,8 @@ class SlackAIChatMessageReactionAdmin(ModelAdmin):
     )
     actions = ["export_csv_thumbs_up_action", "export_csv_thumbs_down_action"]
 
-    def user_link(self, obj):
-        url = reverse("admin:auth_user_change", args=[obj.user.id])
-        return format_html('<a href="{}">{}</a>', url, obj.user.email)
-
-    user_link.short_description = "User"
+    def user_email(self, obj):
+        return obj.user.email
 
     def slack_chat_message_link(self, obj):
         url = reverse(

--- a/baseapp_ai_langkit/slack/slack_ai_chat_controller.py
+++ b/baseapp_ai_langkit/slack/slack_ai_chat_controller.py
@@ -122,21 +122,18 @@ class SlackAIChatController:
                 chunks.append((chunk_text, blocks))
                 break
 
-            # Find the last sentence boundary before the limit
-            last_period = remaining_text[:max_text_length].rfind(".")
-            last_question = remaining_text[:max_text_length].rfind("?")
-            last_exclamation = remaining_text[:max_text_length].rfind("!")
-            sentence_end = max(last_period, last_question, last_exclamation)
-            if sentence_end == -1:
-                sentence_end = remaining_text[:max_text_length].rfind(" ")
-                if sentence_end == -1:
-                    sentence_end = max_text_length - 1
+            # Find the last newline before the max length
+            break_pos = remaining_text[:max_text_length].rfind("\n")
 
-            chunk_text = remaining_text[: sentence_end + 1]
+            # If no newline found or would result in empty chunk, break at max length
+            if break_pos == -1 or break_pos == 0:
+                break_pos = max_text_length - 1
+
+            chunk_text = remaining_text[: break_pos + 1]
             blocks = [dict(type="section", text=dict(type="mrkdwn", text=chunk_text))]
             chunks.append((chunk_text, blocks))
 
-            remaining_text = remaining_text[sentence_end + 1 :].lstrip()
+            remaining_text = remaining_text[break_pos + 1 :].lstrip()
         return chunks
 
     def process_message_response(self, chunks: list[Tuple[str, List[SlackBlock]]]):

--- a/baseapp_ai_langkit/slack/slack_ai_chat_controller.py
+++ b/baseapp_ai_langkit/slack/slack_ai_chat_controller.py
@@ -108,8 +108,6 @@ class SlackAIChatController:
             raise ValueError("The current slack formatter only supports strings as the LLM output.")
 
         max_text_length: int = 3000
-        ellipsis = "..."
-        effective_max_length = max_text_length - len(ellipsis)
 
         if len(llm_output) <= max_text_length:
             blocks = [dict(type="section", text=dict(type="mrkdwn", text=llm_output))]
@@ -118,23 +116,35 @@ class SlackAIChatController:
         chunks = []
         remaining_text = llm_output
         while len(remaining_text) > 0:
-            # Last chunk doesn't need ellipsis
             if len(remaining_text) <= max_text_length:
                 chunk_text = remaining_text
                 blocks = [dict(type="section", text=dict(type="mrkdwn", text=chunk_text))]
                 chunks.append((chunk_text, blocks))
                 break
 
-            chunk_text = remaining_text[:effective_max_length] + ellipsis
+            # Find the last sentence boundary before the limit
+            last_period = remaining_text[:max_text_length].rfind(".")
+            last_question = remaining_text[:max_text_length].rfind("?")
+            last_exclamation = remaining_text[:max_text_length].rfind("!")
+            sentence_end = max(last_period, last_question, last_exclamation)
+            if sentence_end == -1:
+                sentence_end = remaining_text[:max_text_length].rfind(" ")
+                if sentence_end == -1:
+                    sentence_end = max_text_length - 1
+
+            chunk_text = remaining_text[: sentence_end + 1]
             blocks = [dict(type="section", text=dict(type="mrkdwn", text=chunk_text))]
             chunks.append((chunk_text, blocks))
 
-            remaining_text = remaining_text[effective_max_length:]
+            remaining_text = remaining_text[sentence_end + 1 :].lstrip()
         return chunks
 
     def process_message_response(self, chunks: list[Tuple[str, List[SlackBlock]]]):
+        previous_ts = None
         for text, blocks in chunks:
-            output_slack_event_data = self.process_message_response_post_message(text, blocks)
+            output_slack_event_data = self.process_message_response_post_message(
+                text, blocks, previous_ts
+            )
             if output_slack_event_data is not None:
                 output_slack_event = SlackEvent.objects.create(
                     team_id=self.slack_event_data["team_id"],
@@ -148,12 +158,13 @@ class SlackAIChatController:
                     output_slack_event=output_slack_event,
                     output_response_output_data=output_slack_event_data,
                 )
+                previous_ts = output_slack_event_data["message"]["ts"]
 
     def process_message_response_post_message(
-        self, text: str, blocks: list[SlackBlock]
+        self, text: str, blocks: list[SlackBlock], previous_ts: Optional[str] = None
     ) -> dict | None:
         slack_channel: str = self.slack_event_data["event"]["channel"]
-        event_ts: Optional[str] = self.slack_event_data["event"]["event_ts"]
+        event_ts: Optional[str] = previous_ts or self.slack_event_data["event"]["event_ts"]
 
         response = self.slack_instance_controller.slack_web_client.chat_postMessage(
             channel=slack_channel,

--- a/baseapp_ai_langkit/slack/utils/export_reactions_helper.py
+++ b/baseapp_ai_langkit/slack/utils/export_reactions_helper.py
@@ -1,0 +1,88 @@
+import csv
+from datetime import datetime
+
+from django.http import HttpResponse
+
+
+def get_message_content(message_slack_event):
+    if message_slack_event and message_slack_event.data:
+        event_data = message_slack_event.data
+        if "text" in event_data:
+            return event_data["text"]
+        elif "message" in event_data and "text" in event_data["message"]:
+            return event_data["message"]["text"]
+        elif "event" in event_data and "text" in event_data["event"]:
+            return event_data["event"]["text"]
+    return "No content available"
+
+
+def get_message_url(slack_message):
+    if not slack_message.output_slack_event:
+        return "URL not available"
+
+    event_data = slack_message.output_slack_event.data
+
+    channel_id = None
+    timestamp = None
+    thread_ts = None
+
+    if "channel" in event_data:
+        channel_id = event_data["channel"]
+    elif "event" in event_data and "channel" in event_data["event"]:
+        channel_id = event_data["event"]["channel"]
+
+    if "ts" in event_data:
+        timestamp = event_data["ts"]
+    elif "event" in event_data and "ts" in event_data["event"]:
+        timestamp = event_data["event"]["ts"]
+    elif "message" in event_data and "ts" in event_data["message"]:
+        timestamp = event_data["message"]["ts"]
+
+    if "message" in event_data and "thread_ts" in event_data["message"]:
+        thread_ts = event_data["message"]["thread_ts"]
+    elif "event" in event_data and "thread_ts" in event_data["event"]:
+        thread_ts = event_data["event"]["thread_ts"]
+
+    if channel_id and timestamp:
+        ts_without_dot = timestamp.replace(".", "")
+        base_url = f"https://silverlogic.slack.com/archives/{channel_id}/p{ts_without_dot}"
+
+        if thread_ts:
+            return f"{base_url}?thread_ts={thread_ts}&cid={channel_id}"
+        else:
+            return base_url
+
+    return "URL not available"
+
+
+def generate_reaction_export_csv(queryset, reaction_types, reaction_name) -> HttpResponse:
+    reactions = queryset.filter(reaction__in=reaction_types)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"avi_chat_messages_{reaction_name.replace(' ', '_')}_{timestamp}.csv"
+
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+    writer = csv.writer(response)
+    writer.writerow(["ID", "Reactions", "User message", "Output message", "URL"])
+    for reaction in reactions:
+        message = reaction.slack_chat_message
+        user_message = message.user_message_slack_event
+        output_message = message.output_slack_event
+        user_message_content = get_message_content(user_message)
+        output_message_content = get_message_content(output_message)
+
+        print(
+            message.output_response_output_data,
+            message.output_response_output_data.get("channel", ""),
+        )
+        if message.output_response_output_data.get("channel", "").startswith("D"):
+            url = "Direct message"
+        else:
+            url = get_message_url(message)
+
+        writer.writerow(
+            [message.id, reactions.count(), user_message_content, output_message_content, url]
+        )
+
+    return response

--- a/baseapp_ai_langkit/slack/utils/export_reactions_helper.py
+++ b/baseapp_ai_langkit/slack/utils/export_reactions_helper.py
@@ -64,7 +64,7 @@ def generate_reaction_export_csv(queryset, reaction_types, reaction_name) -> Htt
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
     writer = csv.writer(response)
-    writer.writerow(["ID", "Reactions", "User message", "Output message", "URL"])
+    writer.writerow(["ID", "Reactions", "User Email", "User message", "Output message", "URL"])
     for reaction in reactions:
         message = reaction.slack_chat_message
         user_message = message.user_message_slack_event
@@ -72,17 +72,20 @@ def generate_reaction_export_csv(queryset, reaction_types, reaction_name) -> Htt
         user_message_content = get_message_content(user_message)
         output_message_content = get_message_content(output_message)
 
-        print(
-            message.output_response_output_data,
-            message.output_response_output_data.get("channel", ""),
-        )
         if message.output_response_output_data.get("channel", "").startswith("D"):
             url = "Direct message"
         else:
             url = get_message_url(message)
 
         writer.writerow(
-            [message.id, reactions.count(), user_message_content, output_message_content, url]
+            [
+                message.id,
+                reactions.count(),
+                reaction.user.email,
+                user_message_content,
+                output_message_content,
+                url,
+            ]
         )
 
     return response


### PR DESCRIPTION
### Added

- Slack Reactions admin.
- Export CSV of reactions actions.
- Improving the slack output formatting to create the chunks based on break lines.

### Fixed

- Orchestrator workflow: making the synthesizer node clear the memory after erros.
- Slack large responses: chunks are now connected by the previous chunk ts.
