### PR TITLE
BA-3203 Preserve OAuth Tokens between Deployments

### DIFF
--- a/baseapp_mcp/README.md
+++ b/baseapp_mcp/README.md
@@ -66,6 +66,10 @@ MCP_URL = env("MCP_URL", default="http://localhost:8001")
 # Google OAuth credentials
 GOOGLE_OAUTH_CLIENT_ID = env("GOOGLE_OAUTH_CLIENT_ID", default="")
 GOOGLE_OAUTH_CLIENT_SECRET = env("GOOGLE_OAUTH_CLIENT_SECRET", default="")
+
+# MCP Token Storage
+MCP_JWT_SIGNING_KEY = env("MCP_JWT_SIGNING_KEY")
+MCP_STORAGE_ENCRYPTION_KEY = env("MCP_STORAGE_ENCRYPTION_KEY")
 ```
 
 #### MCP tool registration (import paths)
@@ -233,6 +237,13 @@ MCP_URL=http://localhost:8001
 # Google OAuth (required for OAuth authentication)
 GOOGLE_OAUTH_CLIENT_ID=your-client-id
 GOOGLE_OAUTH_CLIENT_SECRET=your-client-secret
+
+# MCP OAuth Token Storage
+# Dummy key for local development - generate real key with 'openssl rand -base64 32'
+MCP_JWT_SIGNING_KEY='abcdefghijklmnopqrstuvwxyz0123456789+++++++=' 
+# Dummy key for local development - generate real key with 
+# python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+MCP_STORAGE_ENCRYPTION_KEY='abcdefghijklmnopqrstuvwxyz0123456789-------='
 ```
 
 ## Creating an MCP App in Your Project

--- a/baseapp_mcp/server/config.py
+++ b/baseapp_mcp/server/config.py
@@ -63,6 +63,7 @@ def get_auth_provider():
         )
     )
 
+
 def _get_redis_store() -> RedisStore:
     """Creates a RedisStore. Uses REDIS_URL if provided, otherwise falls back to individual settings."""
     from django.conf import settings

--- a/baseapp_mcp/server/config.py
+++ b/baseapp_mcp/server/config.py
@@ -1,3 +1,7 @@
+from key_value.aio.stores.redis import RedisStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+from cryptography.fernet import Fernet
+
 from .constants import DEFAULT_MCP_ROUTE_PATH, DEFAULT_SERVER_INSTRUCTIONS
 
 
@@ -52,4 +56,22 @@ def get_auth_provider():
             "openid",
             "https://www.googleapis.com/auth/userinfo.email",
         ],
+        jwt_signing_key=settings.MCP_JWT_SIGNING_KEY,
+        client_storage=FernetEncryptionWrapper(
+            key_value=_get_redis_store(),
+            fernet=Fernet(settings.MCP_STORAGE_ENCRYPTION_KEY)
+        )
     )
+
+def _get_redis_store() -> RedisStore:
+    """Creates a RedisStore. Uses REDIS_URL if provided, otherwise falls back to individual settings."""
+    from django.conf import settings
+
+    redis_url = getattr(settings, "REDIS_URL", None)
+    if redis_url:
+        return RedisStore(url=redis_url)
+
+    redis_host = getattr(settings, "REDIS_HOST", "redis")
+    redis_port = getattr(settings, "REDIS_PORT", 6379)
+    redis_password = getattr(settings, "REDIS_PASSWORD", None)
+    return RedisStore(host=redis_host, port=redis_port, password=redis_password)

--- a/baseapp_mcp/server/config.py
+++ b/baseapp_mcp/server/config.py
@@ -1,6 +1,6 @@
+from cryptography.fernet import Fernet
 from key_value.aio.stores.redis import RedisStore
 from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
-from cryptography.fernet import Fernet
 
 from .constants import DEFAULT_MCP_ROUTE_PATH, DEFAULT_SERVER_INSTRUCTIONS
 
@@ -58,9 +58,8 @@ def get_auth_provider():
         ],
         jwt_signing_key=settings.MCP_JWT_SIGNING_KEY,
         client_storage=FernetEncryptionWrapper(
-            key_value=_get_redis_store(),
-            fernet=Fernet(settings.MCP_STORAGE_ENCRYPTION_KEY)
-        )
+            key_value=_get_redis_store(), fernet=Fernet(settings.MCP_STORAGE_ENCRYPTION_KEY)
+        ),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "baseapp_ai_langkit"
-version = "0.9.0"
+version = "0.9.2"
 description = "A Django app for LLM chat functionality with Langchain and Langgraph integration"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }


### PR DESCRIPTION
Acceptance Criteria

As a user of the BA MCP server, I want to be able to connect to the MCP server via ChatGPT without resetting it after each server deployment.
- Currently OAuth Tokens are stored in the filesystem (default), and therefore get lost when a new version of the MCP is deployed.
- This story is done when the tokens are preserved between deployments. To achieve this, we suggest using a redis store, see below.