### PR TITLE
SPP-5941-ba-langkit-❌-approvd-mcp-initial-setup

### DIFF
--- a/baseapp_mcp/auth/tool_auth.py
+++ b/baseapp_mcp/auth/tool_auth.py
@@ -29,6 +29,15 @@ def _get_permission_for_tool(tool_cls: typ.Type[BaseMCPTool]) -> typ.Optional[st
     return None
 
 
+@database_sync_to_async
+def _email_has_permission(email: str, permission: str) -> bool:
+    try:
+        user = User.objects.get(email=email)
+    except User.DoesNotExist:
+        return False
+    return user.has_perm(permission)
+
+
 def require_tool_permission(tool_cls: typ.Type[BaseMCPTool]) -> typ.Callable:
     async def _check(ctx: AuthContext) -> bool:
         if ctx.token is None:
@@ -36,13 +45,8 @@ def require_tool_permission(tool_cls: typ.Type[BaseMCPTool]) -> typ.Callable:
         if (email := ctx.token.claims.get("email")) and (
             permission := _get_permission_for_tool(tool_cls)
         ):
-            try:
-                user = await User.objects.aget(email=email)
-                has_permission = await database_sync_to_async(user.has_perm)(permission)
-                if has_permission:
-                    return True
-            except User.DoesNotExist:
-                pass
+            if await _email_has_permission(email, permission):
+                return True
         raise AuthorizationError(_("You do not have permission to perform this action."))
 
     return _check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "baseapp_ai_langkit"
-version = "0.10.0"
+version = "0.10.1"
 description = "A Django app for LLM chat functionality with Langchain and Langgraph integration"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }


### PR DESCRIPTION
Acceptance Criteria

As a TSL employee, I want to be able to use information from Approvd (stories, projects) directly in my preferred LLM client.

In this story, we spin up an MCP server for Approvd that TSL employees and clients can connect to.

 

This story is done when:

An MCP server with a debug tool is available for Approvd.

Deployment of the MCP server can be done using spp-composed.

Users can connect to this server via API key or OAuth.

 

 

Additional Information:

Use the BA MCP package for spinning up an MCP server for Approvd. Note that BA backend packages cannot easily be used on Approvd, but the API key package has already been installed. It should be possible to use the MCP package without too many issues.

Set up an OAuth flow (consent screen, etc.) in the Google Cloud, similar to the one for ChatTSL.